### PR TITLE
feature/valet php fpm

### DIFF
--- a/.global.gitignore
+++ b/.global.gitignore
@@ -30,7 +30,7 @@ $RECYCLE.BIN/
 *~
 
 # Php - Composer
-vendor/
+# vendor/ # not this as resources/views/vendor is published to and should be under version control
 
 # General
 log/

--- a/README.md
+++ b/README.md
@@ -92,34 +92,60 @@ js_env_install
 
 ```
 # php helper script - php.sh
-composer_global_install
+install_composer_global
 ```
 
 ### php 
 
 Installing multiple versions of php from `7.0`,`7.2`, `7.4` and `8.0` has become significantly easier on BigSur with the 
 help of `shivammathur/php` and `shivammathur/extensions`. 
+ 
+> Since: 2021-05-01
+> 
+> PHP installation relies more and more on `laravel/valet`'s `use php@n.n` and `install` commands.  
+> A customised `valet/ValetPhpFpm.php` is installed into the laravel home `$HOME/.config/valet/Extensions` and overrides
+> some methods to better support our custom install (_and fixes a few issues - in time these may disappear with each valet release._)
+> 
+> The `switch-php` __npm package__ is no longer used.
+ 
+Two helper functions exist to support installation and re-installation, see `php.sh`
 
-Three helper functions exist to support installation and re-installation, see `php.sh`.
-
-To re-install try this
 ```
-# this sequence can (and may need to) be rerun 
-valet_uninstall
-php_install
-valet_install
+# to re-install try this - this sequence may need to be rerun  
+uninstall_php
+install_php
 ```
 
-You may need to adjust the `adhoc.sh` file if it includes `_switch_php_pre_tasks` or `_switch_php_post_tasks` as these have 
-changed since  __BigSur 2021-01__ changes.
+On initial setup a default brew recipe for the `latest php` and `php@7.0` is installed. 
+After that use the `sphp<nn>` aliases ( see notes below ) to install new versions, e.g
+```
+# to install php 7.4
+sphp74 
+```
+
+Review the contents of `templates/adhoc.sh` as you may need to adjust your own `adhoc.sh` file.
+
+- removal `_switch_php_pre_tasks` or `_switch_php_post_tasks` 
+- introduce `PECL_EXTENSIONS` for automatic installation during `valet use|install` tasks.
+- introduce `BREW_EXTENSIONS` for automatic installation during `valet use|install` tasks.
+
+
 ```
 mv ~/.bash/adhoc.sh ~/.bash/adhoc.sh.pre_big_sur
 cp ~/.bash/templates/adhoc.sh ~/.bash/adhoc.sh
 ```
 
-> **Note**: `valet_uninstall` exists to remove valet and php completely if you are having either/or issues.
-> **Note**: `valet_uninstall` exists to remove valet and php completely if you are having either/or issues.
+### Switching php version
 
+The aliases `sphp70, sphp72, sphp74, sphp80` exist to switch version. 
+
+A macOs task bar tool called Php Monitor is also installed during `php_install` - see `nicoverbruggen/homebrew-cask`.
+
+```
+brew tap nicoverbruggen/homebrew-cask
+brew install --cask phpmon
+```
+> __Note__: the "Php Monitor" toolbar should only be used ONCE each version has been installed via the `sphp<nn>` commands.
 
 ### Postgres 9.5
 

--- a/bash.sh
+++ b/bash.sh
@@ -7,6 +7,9 @@
 [ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion || echo -e "missing bash-completion, try\n\tbrew install bash-completion"
 [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
 
+# Brew
+alias bsl='sudo brew services list'
+
 # Get VSCode extensions
 alias codeextensions='code --list-extensions | xargs -L 1 echo code --install-extension'
 alias subl=code
@@ -47,8 +50,9 @@ function dockspace {
   killall Dock
 }
 
-
+#
 # macOs - what app is running on a port
+#
 function what_port() {
   if [ $# -ne 1 ]; then 
     echo "need to know the port"; 
@@ -61,8 +65,9 @@ function what_port() {
 }
 alias whatport="what_port"
 
-
+#
 # Function to open specified project in projects folder
+#
 function op {
   echo "ENV(WORKSPACE):${WORKSPACE}"
   # to override use set WORKSPACE, e.g. WORKSPACE=~/Documents/Projects op
@@ -103,11 +108,19 @@ function op {
   fi
 }
 
-# #########################################################
+#
 # Allow "tr" to process non-utf8 byte sequences, read random bytes and keep only alphanumerics
+#
 function genRandom() {
   length=${1:-32}
   LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c$length
+}
+
+#
+# get the folder the 'current' script (as called from) is working under, https://stackoverflow.com/questions/59895
+#
+function scriptdir() {
+  echo "$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 }
 
 # #########################################################
@@ -164,7 +177,7 @@ function ssh_prepare_keyexchange() {
 
 # macOs - check for expected brew installs
 function brew_check_installation() {
-    for formula in httpie wget gettext htop bash-completion zlib jq pkg-config tree
+    for formula in httpie wget gettext htop bash-completion zlib jq pkg-config tree tmux
     do
         if [ "" = "`brew ls --versions $forumla`" ]; then
             echo "install brew install $forumla"

--- a/js.sh
+++ b/js.sh
@@ -3,7 +3,7 @@
 # #########################################################
 #    JS Node NPM
 
-alias fixjs='rm -rf node_modules/ && npm install'
+alias fixjs='rm -rf node_modules/;npm cache clear --force && npm install'
 alias ng='npm list -g --depth=0'
 alias nl='npm list --depth=0'
 

--- a/templates/.bash_profile
+++ b/templates/.bash_profile
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-export phpversions="7.2 7.4 8.0"
 
 # Read ~/.profile as ~/.bash_profile makes ~/.profile obsolete and ignores it
 [ -f ~/.credentials ] && source ~/.credentials
@@ -7,4 +6,8 @@ export phpversions="7.2 7.4 8.0"
 [ -f ~/.bash/includes.sh ] && source ~/.bash/includes.sh
 [ -f ~/.bash/adhoc.sh ] && source ~/.bash/adhoc.sh
 
-export PATH="${PATH}:~/bin:/usr/local/bin:/usr/local/sbin" # keep me at the end of scripts
+for binpath in ~/bin /usr/local/bin /usr/local/sbin;
+do
+  echo $PATH | grep $binpath &>/dev/null && true || export PATH="$PATH:$binpath" # add path if missing
+done
+

--- a/templates/adhoc.sh
+++ b/templates/adhoc.sh
@@ -5,54 +5,8 @@
 # Overrides Workspace location - used in 'op' command
 export WORKSPACE=$HOME/Workspace
 
+# As used in valet/ValetPhpFpm.php
+export BREW_EXTENSIONS=''
+export PECL_EXTENSIONS='redis|apcu|memcached'
+
 alias vagrant="HOMESTEADVM='centos' vagrant"
-
-function _switch_php_pre_tasks() {
-    [ $# -lt 1 ] && return 1
-    phpver=$1
-    verbose="${2:-0}"
-
-    if [ "${phpver}" = 'php@7.0' ]; then
-        [ "${verbose}" -eq 1 ] && echo " 🚩  Dyld fixing at (icu4c 64.2, openssl 1.0.2) for ${phpver}.";
-        switch_icu4c64_2 &>/dev/null || echo " 🚩 - icu4c 64.2 missing - brew extract --version 64.2 -v -d --force icu4c bgdevlab/deprecated && HOMEBREW_NO_INSTALL_CLEANUP=true brew reinstall icu4c@64.2"
-        switch_openssl1_0 &>/dev/null || echo " 🚩 - openssl 1.0.2 missing - brew extract --version 1.0 -v -d --force openssl bgdevlab/deprecated && HOMEBREW_NO_INSTALL_CLEANUP=true brew reinstall openssl@1.0"
-    else
-        [ "${verbose}" -eq 1 ] && echo " 🚩  Dyld reverting to (icu4c 67.1) for ${phpver}.";
-        switch_icu4c67_1 &>/dev/null || echo " 🚩 - icu4c 67.1 missing - brew install icu4c -v"
-    fi
-
-}
-
-function _switch_php_post_tasks() {
-    [ $# -lt 1 ] && return 1
-    phpver=$1
-    verbose="${2:-0}"
-
-    if [ "${phpver}" = 'php@7.0' ]; then
-        [ "${verbose}" -eq 1 ] && echo " 🚩  Dyld fixing at (icu4c 64.2, openssl 1.0.2) for ${phpver}.";
-        switch_icu4c64_2 &>/dev/null || echo " 🚩 - icu4c 64.2 missing - brew extract --version 64.2 -v -d --force icu4c bgdevlab/deprecated && HOMEBREW_NO_INSTALL_CLEANUP=true brew reinstall icu4c@64.2"
-        switch_openssl1_0 &>/dev/null || echo " 🚩 - openssl 1.0.2 missing - brew extract --version 1.0 -v -d --force openssl bgdevlab/deprecated && HOMEBREW_NO_INSTALL_CLEANUP=true brew reinstall openssl@1.0"
-        type -p nvm &>/dev/null && nvm use default
-    else
-        [ "${verbose}" -eq 1 ] && echo " 🚩  Dyld reverting to (icu4c 67.1) for ${phpver}.";
-        switch_icu4c67_1 &>/dev/null || echo " 🚩 - icu4c 67.1 missing - brew install icu4c -v"
-        type -p nvm &>/dev/null && nvm use stable && nvm
-    fi
-}
-
-function _switch_php_pre_tasks() {
-    [ $# -lt 1 ] && return 1
-    phpver=$1
-    verbose="${2:-0}"
-    [ "${verbose}" -eq 1 ] && echo " 🍾 no hacks required for ${phpver}, thankfully relying on brew tap shivammathur/php and shivammathur/extensions";
-}
-
-function _switch_php_post_tasks() {
-    [ $# -lt 1 ] && return 1
-    phpver=$1
-    verbose="${2:-0}"
-    [ "${verbose}" -eq 1 ] && echo " 🍾 no hacks required for ${phpver}, thankfully relying on brew tap shivammathur/php and shivammathur/extensions";
-}
-
-#export -f _switch_php_pre_tasks
-export -f _switch_php_post_tasks

--- a/valet/ValetPhpFpm.php
+++ b/valet/ValetPhpFpm.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Valet;
+
+use Illuminate\Container\Container;
+
+/*
+ * Fix some of our issues with Valet.
+ * Create ValetPhpFpm class (extend Valet's PhpFpm class) and swap the instance in the container.
+ * We address the following
+ *
+ *  1 - include  'shivammathur/extensions' for Brew
+ *  2 - fix the PhpFpm->stopRunning method - use `sudo` when calling `brew services stop php@V.V`
+ *  3 - include support for installing pecl extensions
+ *
+ */
+
+class ValetPhpFpm extends PhpFpm
+{
+    var $taps = [
+        'homebrew/homebrew-core',
+        'shivammathur/php',
+        'shivammathur/extensions',
+    ];
+
+    /**
+     * Support Custom prebuilt extensions
+     * keys are used for `php -m` checks, values are brew formula.
+     * TODO - support custom exts - extract to BREW_EXTENSIONS similar to PECL_EXTENSIONS below
+     * @var string[]
+     */
+    var $brewExtensions = [
+        'imagick' => 'shivammathur/extensions/imagick',
+        'imap' => 'shivammathur/extensions/imap',
+    ];
+
+    /**
+     * Support Custom pecl extensions ( override bar delimited env PECL_EXTENSIONS ).
+     * @var string[]
+     */
+    var $peclExtensions = [
+    ];
+
+    /**
+     * Log file for feedback aswell as stdout - used by logit.
+     */
+    const LOGFILE = VALET_HOME_PATH.'/Log/valet-php-fpm.log';
+
+    /**
+     * Install and configure PhpFpm.
+     *
+     * @return void
+     */
+    function install()
+    {
+        $this->logit("\n".ValetPhpFpm::class."::install - Start");
+        $this->peclExtensions = explode('|', getenv('PECL_EXTENSIONS') ?: 'redis');
+//        $this->brewExtensions = explode('|',
+//            getenv('BREW_EXTENSIONS') ?: 'shivammathur/extensions/imagick|shivammathur/extensions/imap');
+
+        # parent block start
+        parent::install();
+        # parent block end
+
+        $phpVersion = $this->brew->linkedPhp();
+        $version = preg_replace('/[^\d\.]/', '', $phpVersion);
+        $fpmConfig = $this->fpmConfigPath();
+
+        $this->logit("Linked PHP is '$version', version is $version. Fpm Config $fpmConfig");
+
+        $this->installPhpExtensions($version);
+        $this->installPeclExtensions($version);
+        $this->checkExtensions();
+        $this->logit(ValetPhpFpm::class."::install - End");
+    }
+
+    /**
+     * Only stop running php services
+     */
+    function stopRunning()
+    {
+        $this->logit(ValetPhpFpm::class."::stopRunning - Start");
+        //
+        // this varies from laravel valet's standard position which only stops 'running' php processes.
+        // we assume issues with valet and force stop on any matching php process (as sudo).
+        //
+        $this->brew->stopService(
+            collect(array_filter(explode(PHP_EOL, $this->cli->runAsUser(
+                'sudo brew services list | grep "^php" | awk \'{ print $1; }\'',
+                function ($exitCode, $errorOutput) {
+                    $this->logit($errorOutput);
+
+                    throw new DomainException('Brew was unable to check which services are running.');
+                }
+            ))))
+                ->filter(function ($service) {
+                    return substr($service, 0, 3) === 'php';
+                })
+                ->all()
+        );
+        $this->logit(ValetPhpFpm::class."::stopRunning - End");
+    }
+
+    protected function logit($message)
+    {
+        info($message);
+        file_put_contents(ValetPhpFpm::LOGFILE, "$message\n", FILE_APPEND);
+    }
+
+    /**
+     * Support PeclExtension installation
+     * @param $version
+     */
+    protected function installPeclExtensions($version)
+    {
+        $this->logit(ValetPhpFpm::class."::installPeclExtensions ($version) - Start");
+
+        collect($this->peclExtensions)
+            ->reject(function ($pecl) use ($version) { # reject already loaded pecls
+                // Require existing PECL extensions area available
+                $extensionLoaded = $this->requirePeclExtension($pecl, $version);
+
+                return $extensionLoaded;
+            })
+            ->map(function ($pecl) use ($version) {
+                // Install PECL extensions
+                $this->logit(ValetPhpFpm::class."::installPeclExtensions ($version) - pecl install $pecl ");
+                $result = $this->cli->runAsUser("printf \"\n\" | pecl install $pecl &>/dev/null",
+                    function ($exitCode, $errorOutput) use ($pecl) {
+                        $this->logit($errorOutput);
+
+                        throw new DomainException('Pecl was unable to install ['.$pecl.'].');
+                    });
+                $extensionLoaded = $this->requirePeclExtension($pecl, $version);
+
+                return $pecl;
+            });
+
+        $this->logit(ValetPhpFpm::class."::installPeclExtensions ($version) - End");
+    }
+
+
+    /**
+     * Support PhpExtension installation
+     * @param $version
+     */
+    protected function installPhpExtensions($version)
+    {
+        $this->logit(ValetPhpFpm::class."::installPhpExtensions ($version) - Start");
+
+        collect($this->brewExtensions)
+            ->map(function ($formula, $name) use ($version) {
+                return sprintf("%s@%s", $formula, $version); # redis to redis@7.2
+            })->each(function ($formula) {
+                if (!$this->brew->installed($formula)) {
+                    $this->logit("PHP dependency missing .... $formula");
+                    $this->brew->installOrFail($formula, [], $this->taps);
+                } else {
+                    $this->logit("PHP dependency exists ..... $formula");
+                }
+            });
+        $this->logit(ValetPhpFpm::class."::installPhpExtensions ($version) - End");
+    }
+
+    function checkExtensions()
+    {
+        $modules = collect($this->brewExtensions)->keys()->merge($this->peclExtensions);
+        $this->logit("Extensions check ".$modules->implode('|'));
+        $result = $this->cli->runAsUser("php -m | egrep '".$modules->implode('|')."' | wc -l",
+            function ($exitCode, $errorOutput) {
+                $this->logit($errorOutput);
+
+                throw new DomainException('Unable to check extensions.');
+            });
+        $this->logit($result == $modules->count() ? 'All extensions loaded' : '🤞 Some extensions not loaded !!');
+    }
+
+    /**
+     * @param $pecl
+     * @param $version
+     * @return bool
+     */
+    protected function requirePeclExtension($pecl, $version)
+    {
+        // 1 : is extension installed
+        $peclInstalled = trim($this->cli->runAsUser("pecl info $pecl &>/dev/null && echo true || echo false;")) == 'true';
+
+        // 2 : is it loaded
+        $extensionLoaded = trim($this->cli->runAsUser('[ "$(php -m | egrep -e \'^'.$pecl.'\' | wc -l)" -eq 1 ] && echo true || echo false;')) == 'true';
+
+        $this->logit(ValetPhpFpm::class."::installPeclExtensions ($version) - pecl '$pecl' ".
+            ($peclInstalled ? 'exists' : 'is missing')." and is ".($extensionLoaded ? 'loaded' : 'NOT loaded'));
+
+        if ($peclInstalled == true && $extensionLoaded == false) {
+            // its installed lets try fixing the loading via the INI file.
+            $extensionIniPath = "/usr/local/etc/php/$version/conf.d/$pecl.ini";
+            $extensionLibPath = trim($this->cli->runAsUser('find $(php-config --extension-dir) -name "*'.$pecl.'.so" || echo \'\';'));
+
+            $this->logit(ValetPhpFpm::class." fix Pecl module - add the missing INI file '$extensionIniPath'");
+            $this->files->putAsUser($extensionIniPath, "[$pecl]".PHP_EOL."extension='$extensionLibPath'".PHP_EOL);
+
+            $extensionLoaded = (boolean) $this->cli->runAsUser('[ "$(php -m | egrep -e \'^'.$pecl.'\' | wc -l)" -eq 1 ] && echo true || echo false;');
+
+            $this->logit(ValetPhpFpm::class."::installPeclExtensions ($version) - pecl '$pecl' ".
+                ($peclInstalled ? 'exists' : 'is missing')." and is ".($extensionLoaded ? 'loaded' : 'NOT loaded'));
+        }
+
+        return $extensionLoaded;
+    }
+}
+
+/*
+ * Swap the containers PhpFpm instance used in any valet calls with out custom Class.
+ */
+swap(PhpFpm::class, (Container::getInstance())->make('Valet\\ValetPhpFpm'));


### PR DESCRIPTION
Installing multiple versions of php from 7.0, 7.2, 7.4 and 8.0 has become significantly easier on BigSur with the help of shivammathur/php and shivammathur/extensions.

_Since: 2021-05-01_

PHP installation relies more and more on laravel/valet's use php@n.n and install commands.
A customised valet/ValetPhpFpm.php is installed into the laravel home $HOME/.config/valet/Extensions and overrides some methods to better support our custom install (and fixes a few issues - in time these may disappear with each valet release.)

The switch-php npm package is no longer used.

### Switching php version
The aliases sphp70, sphp72, sphp74, sphp80 exist to switch version.

A macOs task bar tool called Php Monitor is also installed during php_install - see `nicoverbruggen/homebrew-cask`.

```
brew tap nicoverbruggen/homebrew-cask
brew install --cask phpmon
```
**Note:** the "Php Monitor" toolbar should only be used ONCE each version has been installed via the sphp<nn> commands.